### PR TITLE
feat: add local container test service

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Local Container Testing Service
+
+A minimal Go-based testing service lives under `go/cmd/tester`. It exposes an HTTP server on port `8080` with a WebSocket endpoint that streams Docker build output and then provides an interactive shell.
+
+Start the service with:
+
+```bash
+cd go
+go run cmd/tester/main.go
+```
+
+With the service running, open `http://localhost:3000/tester` and provide both the backend URL (for example, `http://localhost:8080`) and a URL to the YAML specification. The UI will open a new tab with an xterm.js terminal that streams build output and then drops into an interactive shell.
+

--- a/app/tester/page.tsx
+++ b/app/tester/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { useTheme } from "@/lib/ThemeContext";
+import { inputStyles, buttonStyles, cn } from "@/lib/styles";
+
+export default function TesterPage() {
+  const { isDark } = useTheme();
+  const [backend, setBackend] = useState("http://localhost:8080");
+  const [spec, setSpec] = useState("");
+
+  const openTerminal = () => {
+    if (!backend || !spec) return;
+    const url = `/tester/terminal?backend=${encodeURIComponent(backend)}&spec=${encodeURIComponent(spec)}`;
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4 space-y-4">
+      <div>
+        <label className={cn("mb-1 block")}>Backend URL</label>
+        <input
+          className={cn(inputStyles(isDark), "w-full")}
+          value={backend}
+          onChange={(e) => setBackend(e.target.value)}
+          placeholder="http://localhost:8080"
+        />
+      </div>
+      <div>
+        <label className={cn("mb-1 block")}>Spec YAML URL</label>
+        <input
+          className={cn(inputStyles(isDark), "w-full")}
+          value={spec}
+          onChange={(e) => setSpec(e.target.value)}
+          placeholder="https://example.com/build.yaml"
+        />
+      </div>
+      <button
+        onClick={openTerminal}
+        className={buttonStyles(isDark, "primary", "md")}
+      >
+        Open Test Terminal
+      </button>
+    </div>
+  );
+}
+

--- a/app/tester/terminal/page.tsx
+++ b/app/tester/terminal/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import Script from "next/script";
+
+declare global {
+  interface Window {
+    Terminal: any;
+  }
+}
+
+export default function TerminalPage() {
+  const params = useSearchParams();
+  const termRef = useRef<HTMLDivElement>(null);
+
+  const init = () => {
+    const backend = params.get("backend");
+    const spec = params.get("spec");
+    if (!backend || !spec || !termRef.current) return;
+    const term = new window.Terminal();
+    term.open(termRef.current);
+    const wsURL = backend.replace(/^http/, "ws") + `/ws?spec=${encodeURIComponent(spec)}`;
+    const ws = new WebSocket(wsURL);
+    ws.onmessage = (e) => term.write(e.data);
+    term.onData((d: string) => ws.send(d));
+  };
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.Terminal) {
+      init();
+    }
+  }, []);
+
+  return (
+    <div className="w-full h-screen">
+      <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css"
+      />
+      <Script
+        src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"
+        onLoad={init}
+      />
+      <div ref={termRef} className="w-full h-full" />
+    </div>
+  );
+}
+

--- a/go/cmd/tester/main.go
+++ b/go/cmd/tester/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+	"github.com/neurodesk/neurocontainers-ui/internal/builder"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+func main() {
+	http.HandleFunc("/ws", handleWS)
+	log.Println("serving on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func handleWS(w http.ResponseWriter, r *http.Request) {
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer c.Close()
+
+	specURL := r.URL.Query().Get("spec")
+	if specURL == "" {
+		c.WriteMessage(websocket.TextMessage, []byte("spec query param required\n"))
+		return
+	}
+
+	specPath, err := downloadFile(r.Context(), specURL)
+	if err != nil {
+		c.WriteMessage(websocket.TextMessage, []byte("download failed: "+err.Error()+"\n"))
+		return
+	}
+	defer os.Remove(specPath)
+
+	b := &builder.PythonBuilder{ScriptURL: "https://raw.githubusercontent.com/NeuroDesk/neurocontainers/main/builder/build.py"}
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			c.WriteMessage(websocket.TextMessage, append(scanner.Bytes(), '\n'))
+		}
+		close(done)
+	}()
+	buildDir, err := b.Run(r.Context(), specPath, pw)
+	pw.Close()
+	<-done
+	if err != nil {
+		c.WriteMessage(websocket.TextMessage, []byte("builder error: "+err.Error()+"\n"))
+		return
+	}
+
+	buildCmd := exec.CommandContext(r.Context(), "docker", "build", "-t", "built-image", buildDir)
+	buildCmd.Stdout = wsWriter{c}
+	buildCmd.Stderr = wsWriter{c}
+	if err := buildCmd.Run(); err != nil {
+		c.WriteMessage(websocket.TextMessage, []byte("docker build error: "+err.Error()+"\n"))
+		return
+	}
+
+	cmd := exec.CommandContext(r.Context(), "docker", "run", "-it", "--rm", "built-image", "/bin/bash")
+	f, err := pty.Start(cmd)
+	if err != nil {
+		c.WriteMessage(websocket.TextMessage, []byte("terminal start failed: "+err.Error()+"\n"))
+		return
+	}
+	go func() {
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			f.Write(msg)
+		}
+	}()
+	io.Copy(wsWriter{c}, f)
+}
+
+type wsWriter struct{ *websocket.Conn }
+
+func (w wsWriter) Write(p []byte) (int, error) {
+	err := w.Conn.WriteMessage(websocket.BinaryMessage, p)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func downloadFile(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	f, err := os.CreateTemp("", "spec-*.yaml")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err = io.Copy(f, resp.Body); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,9 @@
+module github.com/neurodesk/neurocontainers-ui
+
+go 1.24.3
+
+require (
+    github.com/creack/pty v1.1.18
+    github.com/gorilla/websocket v1.5.1
+)
+

--- a/go/internal/builder/builder.go
+++ b/go/internal/builder/builder.go
@@ -1,0 +1,51 @@
+package builder
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type Builder interface {
+	Run(ctx context.Context, yamlPath string, w io.Writer) (string, error)
+}
+
+type PythonBuilder struct {
+	ScriptURL string
+}
+
+func (b *PythonBuilder) Run(ctx context.Context, yamlPath string, w io.Writer) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "builder")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	scriptPath := filepath.Join(tmpDir, "builder.py")
+	resp, err := http.Get(b.ScriptURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	f, err := os.Create(scriptPath)
+	if err != nil {
+		return "", err
+	}
+	if _, err = io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		return "", err
+	}
+	f.Close()
+
+	cmd := exec.CommandContext(ctx, "python", scriptPath, yamlPath)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return filepath.Dir(yamlPath), nil
+}


### PR DESCRIPTION
## Summary
- refactor Go tester to use github.com/neurodesk/neurocontainers-ui module path, run Python builder and Docker build via WebSocket endpoint
- add Next.js tester UI with configurable backend URL and xterm.js terminal
- document how to launch the tester service and connect through the UI

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: missing go.sum entry for module providing github.com/creack/pty)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b13e224c488333898bcff2f89f5a15