### PR TITLE
Improve mobile layout for container wizard

### DIFF
--- a/components/GuidedTour.tsx
+++ b/components/GuidedTour.tsx
@@ -617,23 +617,41 @@ const GuidedTour: React.FC<GuidedTourProps> = ({
                                 Container Summary
                             </h4>
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                                <div>
-                                    <span className={cn(
-                                        "font-medium",
-                                        isDark ? "text-gray-300" : "text-gray-700"
-                                    )}>Name:</span>{" "}
-                                    <span className={cn(
-                                        isDark ? "text-white" : "text-gray-900"
-                                    )}>{String(formData.containerName || formData.name || 'Unnamed')}</span>
+                                <div className="flex flex-col sm:flex-row sm:items-center sm:gap-1">
+                                    <span
+                                        className={cn(
+                                            "font-medium",
+                                            isDark ? "text-gray-300" : "text-gray-700"
+                                        )}
+                                    >
+                                        Name:
+                                    </span>
+                                    <span
+                                        className={cn(
+                                            "break-all",
+                                            isDark ? "text-white" : "text-gray-900"
+                                        )}
+                                    >
+                                        {String(formData.containerName || formData.name || 'Unnamed')}
+                                    </span>
                                 </div>
-                                <div>
-                                    <span className={cn(
-                                        "font-medium",
-                                        isDark ? "text-gray-300" : "text-gray-700"
-                                    )}>Version:</span>{" "}
-                                    <span className={cn(
-                                        isDark ? "text-white" : "text-gray-900"
-                                    )}>{String(formData.version || '1.0.0')}</span>
+                                <div className="flex flex-col sm:flex-row sm:items-center sm:gap-1">
+                                    <span
+                                        className={cn(
+                                            "font-medium",
+                                            isDark ? "text-gray-300" : "text-gray-700"
+                                        )}
+                                    >
+                                        Version:
+                                    </span>
+                                    <span
+                                        className={cn(
+                                            "break-all",
+                                            isDark ? "text-white" : "text-gray-900"
+                                        )}
+                                    >
+                                        {String(formData.version || '1.0.0')}
+                                    </span>
                                 </div>
                                 <div>
                                     <span className={cn(


### PR DESCRIPTION
## Summary
- Prevent container name and version from cramping on small screens by stacking them vertically in the wizard's review step

## Testing
- `go fmt ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e2460ff08333acb338acf0b01662