### PR TITLE
Fix mobile layout for container configuration step

### DIFF
--- a/components/GuidedTour.tsx
+++ b/components/GuidedTour.tsx
@@ -285,11 +285,9 @@ const GuidedTour: React.FC<GuidedTourProps> = ({
 
             return (
                 <div
-                    key={field.id}
                     className={cn(
                         "p-4 rounded-lg shadow-sm",
-                        isDark ? "bg-white/5" : "bg-white/90",
-                        field.id === "githubUrl" ? "col-span-2" : ""
+                        isDark ? "bg-white/5" : "bg-white/90"
                     )}
                 >
                     <label
@@ -570,22 +568,29 @@ const GuidedTour: React.FC<GuidedTourProps> = ({
                                 // GitHub URL full width
                                 if (field.id === "githubUrl") {
                                     return (
-                                        <div key={field.id} className="col-span-2">
+                                        <div key={field.id} className="lg:col-span-2">
                                             {renderField(field)}
                                         </div>
                                     );
                                 }
                                 // Container Name and Version on same row
                                 if (field.id === "containerName" || field.id === "version") {
-                                    return renderField(field);
+                                    return (
+                                        <React.Fragment key={field.id}>{renderField(field)}</React.Fragment>
+                                    );
                                 }
                                 // R Package Name on same row as R Version for R templates
-                                if (selectedTemplate.id === 'r-package' && (field.id === "rPackageName" || field.id === "rVersion")) {
-                                    return renderField(field);
+                                if (
+                                    selectedTemplate.id === 'r-package' &&
+                                    (field.id === "rPackageName" || field.id === "rVersion")
+                                ) {
+                                    return (
+                                        <React.Fragment key={field.id}>{renderField(field)}</React.Fragment>
+                                    );
                                 }
                                 // All others full width
                                 return (
-                                    <div key={field.id} className="col-span-2">
+                                    <div key={field.id} className="lg:col-span-2">
                                         {renderField(field)}
                                     </div>
                                 );


### PR DESCRIPTION
## Summary
- prevent mobile wizard inputs from creating unintended extra columns
- apply responsive full-width wrapping for fields that should span two columns on desktop

## Testing
- `go fmt ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@xterm%2fxterm)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e7412bf083339d673c92c82b28e9