### PR TITLE
Fix mobile header layout to prevent horizontal scrolling

### DIFF
--- a/components/tabs/HomeTab.tsx
+++ b/components/tabs/HomeTab.tsx
@@ -60,7 +60,7 @@ export function HomeTab() {
     <div className={cn(layout.container, "py-4 sm:py-6")}> 
       <div className="text-center mb-8 mt-8">
         <div
-          className="inline-flex items-center gap-4 mb-4 group"
+          className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-4 group"
         >
           <div className="transition-transform duration-200 group-hover:scale-105">
             <Logo className="h-12 w-auto" />


### PR DESCRIPTION
## Summary
- Stack logo and title vertically on HomeTab for better mobile layout

## Testing
- `go fmt ./...` *(fails: directory prefix . does not contain main module)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ed8b1fcc833388bd7b5e913200be