### PR TITLE
use lowercase c in Neurocontainers title

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import { GeistMono, GeistSans } from "@/components/fonts";
 import { ThemeProvider } from "@/lib/ThemeContext";
 
 export const metadata: Metadata = {
-  title: "NeuroContainers Builder",
+  title: "Neurocontainers Builder",
   description: "Build neurocontainers with ease",
 };
 

--- a/components/layout/Ribbon.tsx
+++ b/components/layout/Ribbon.tsx
@@ -24,7 +24,7 @@ export function Ribbon() {
         {/* Brand */}
         <div className="flex items-center gap-2 flex-shrink-0">
           <Logo className="h-5 w-auto" />
-          <span className={cn(textStyles(isDark, { size: 'xs', color: 'secondary' }), "hidden xs:inline")}>NeuroContainers Builder</span>
+          <span className={cn(textStyles(isDark, { size: 'xs', color: 'secondary' }), "hidden xs:inline")}>Neurocontainers Builder</span>
         </div>
 
         {/* Actions: use a horizontally scrollable region on small screens */}

--- a/components/layout/TopHeader.tsx
+++ b/components/layout/TopHeader.tsx
@@ -12,7 +12,7 @@ export function TopHeader() {
       isDark ? "bg-[#080a07] border-[#1f2e18]" : "bg-white border-[#e6f1d6]"
     )}>
       <Logo className="h-5 w-auto" />
-      <span className={cn("text-xs", isDark?"text-[#91c84a]":"text-green-700")}>NeuroContainers Builder</span>
+      <span className={cn("text-xs", isDark?"text-[#91c84a]":"text-green-700")}>Neurocontainers Builder</span>
     </div>
   );
 }

--- a/components/tabs/HomeTab.tsx
+++ b/components/tabs/HomeTab.tsx
@@ -68,7 +68,7 @@ export function HomeTab() {
           <h1 className={cn("text-3xl font-bold transition-colors duration-200",
             isDark ? "text-[#e8f5d0] group-hover:text-[#91c84a]" : "text-[#0c0e0a] group-hover:text-[#4f7b38]"
           )}>
-            NeuroContainers Builder
+            Neurocontainers Builder
           </h1>
         </div>
         <p className={cn("text-lg mb-8", isDark ? "text-[#91c84a]" : "text-[#4f7b38]")}>

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -5,10 +5,10 @@ test.describe('NeuroContainers UI Homepage', () => {
     await page.goto('/');
 
     // Check page title
-    await expect(page).toHaveTitle(/NeuroContainers/);
+    await expect(page).toHaveTitle(/Neurocontainers/);
 
     // Check main heading exists
-    await expect(page.locator('h1')).toContainText('NeuroContainers Builder');
+    await expect(page.locator('h1')).toContainText('Neurocontainers Builder');
 
     // Check main action buttons exist
     await expect(page.locator('text=Create New Container')).toBeVisible();
@@ -78,7 +78,7 @@ test.describe('NeuroContainers UI Homepage', () => {
       await themeToggle.click();
       
       // Theme should change (we'll check if page still loads without errors)
-      await expect(page.locator('h1')).toContainText('NeuroContainers Builder');
+      await expect(page.locator('h1')).toContainText('Neurocontainers Builder');
     }
   });
 
@@ -90,7 +90,7 @@ test.describe('NeuroContainers UI Homepage', () => {
     await page.goto('/');
 
     // Page should still load despite API failures
-    await expect(page.locator('h1')).toContainText('NeuroContainers Builder');
+    await expect(page.locator('h1')).toContainText('Neurocontainers Builder');
     await expect(page.locator('text=Create New Container')).toBeVisible();
 
     // Published containers section may show error, but that's expected


### PR DESCRIPTION
## Summary
- use lowercase c in Neurocontainers Builder across homepage UI components
- update e2e tests to expect Neurocontainers casing

## Testing
- `go fmt ./...` (fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)
- `npm test` (fails: jest: not found)
- `npm run test:e2e` (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b5440f122c8333aff545a3599d156b