### PR TITLE
fix: ensure consistent YAML quoting when publishing

### DIFF
--- a/components/validate.tsx
+++ b/components/validate.tsx
@@ -257,7 +257,7 @@ export default function ContainerValidator({
     }, [validationResult?.dockerfile]);
     
     // Handle GitHub issue creation
-    const handleCreateIssue = useCallback((isUpdate: boolean = false) => {
+    const handleCreateIssue = useCallback(async (isUpdate: boolean = false) => {
         if (!recipe) return;
 
         // Regenerate groups and structured readme before publishing
@@ -266,10 +266,10 @@ export default function ContainerValidator({
 
         const yamlText = generateYAMLString(updatedRecipe);
         const compressedYaml = compressToBase64(yamlText);
-        
+
         const action = isUpdate ? 'Update' : 'Add';
         const issueTitle = `[CONTRIBUTION] ${action} ${updatedRecipe.name} container`;
-        
+
         const issueBodyWithYaml = `### ${action} Container Request
 
 **Container Name:** ${updatedRecipe.name}
@@ -285,7 +285,7 @@ ${compressedYaml}
 *This issue was generated automatically by the Neurocontainers Builder UI*`;
 
         const isContentTooLarge = new Blob([issueBodyWithYaml]).size > 6 * 1024;
-        
+
         let issueBody;
         if (isContentTooLarge) {
             issueBody = `### ${action} Container Request
@@ -303,6 +303,12 @@ Please paste the compressed YAML content from your clipboard below:
 
 ---
 *This issue was generated automatically by the Neurocontainers Builder UI*`;
+
+            try {
+                await navigator.clipboard.writeText(compressedYaml);
+            } catch (err) {
+                console.error('Failed to copy compressed YAML to clipboard:', err);
+            }
         } else {
             issueBody = issueBodyWithYaml;
         }
@@ -312,7 +318,7 @@ Please paste the compressed YAML content from your clipboard below:
         targetUrl.searchParams.append("body", issueBody);
 
         window.open(targetUrl.toString(), "_blank", "noopener,noreferrer");
-    }, [recipe, generateYAMLString, compressToBase64]);
+    }, [recipe, generateYAMLString, compressToBase64, regenerateRecipe]);
     
     // Determine button state and text
     const getButtonState = () => {

--- a/hooks/useContainerPublishing.ts
+++ b/hooks/useContainerPublishing.ts
@@ -17,7 +17,8 @@ export function useContainerPublishing() {
                 indent: 2,
                 lineWidth: -1,
                 noRefs: true,
-                sortKeys: true
+                sortKeys: true,
+                quotingType: '"'
             }).trim();
         } catch {
             // If parsing fails, just trim whitespace
@@ -37,7 +38,8 @@ export function useContainerPublishing() {
                 indent: 2,
                 lineWidth: -1,
                 noRefs: true,
-                sortKeys: true
+                sortKeys: true,
+                quotingType: '"'
             });
 
             // Normalize both for comparison


### PR DESCRIPTION
## Summary
- preserve quoting for long YAML lines in container publishing logic
- copy compressed YAML to clipboard when GitHub issue body is too long for URL

## Testing
- `go fmt ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@xterm%2fxterm)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b8258f6d248333b5700eb77f5e0235